### PR TITLE
Windows formatting, missing exception handler

### DIFF
--- a/fREedom.py
+++ b/fREedom.py
@@ -25,6 +25,10 @@ class UnsupportedArch(Exception):
    def __init__(self, msg):
       Exception.__init__(self, msg)
 
+class UnsupportedFormat(Exception):
+   def __init__(self, msg):
+      Exception.__init__(self,msg)
+
 def main(args):
 
    # cycle through available loaders, if one matches

--- a/loader.py
+++ b/loader.py
@@ -66,7 +66,7 @@ class Loader(object):
 
    def __init__(self, fname):
       self.exe = fname
-      f = open(fname)
+      f = open(fname, 'rb')
       self.raw = f.read()
       self.md5 = hashlib.md5(self.raw).hexdigest()
       self.sha1 = hashlib.sha1(self.raw).hexdigest()
@@ -170,7 +170,7 @@ class Loader(object):
 
    def get_dword(self, addr):
       try:
-         return struct.unpack(self.endian + "I", self.get_bytes(addr, 4))[0]
+	 return struct.unpack(self.endian + "I", self.get_bytes(addr, 4))[0]
       except Exception, e:
          print "Unable to read dword from address 0x%x" % addr
          raise e


### PR DESCRIPTION
Explicitly added 'rb' to make freedom.py work on Windows platforms.  Additionally added missing exception handler for UnsupportedFormat()
